### PR TITLE
Fix node module usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "4"
 before_script:
   - npm install -g bower
   - bower install

--- a/README.md
+++ b/README.md
@@ -126,6 +126,25 @@ In case the HTML integration is troublesome in your setup, the library has been 
 </script>
 ````
 
+#### Node module
+
+Add to your `package.json`:
+```
+"dependencies": {
+  "adyen-cse-js": "git+https://github.com/Adyen/CSE-JS.git#v0.1.XX"
+}
+```
+
+Then run `npm install`.
+
+Now you can use adyen as a regular npm package:
+
+```js
+var adyenEncrypt = require('adyen-cse-js');
+
+var cseInstance = adyenEncrypt.createEncryption(key, options);
+```
+
 
 # Version History
 

--- a/js/adyen.encrypt.nodom.js
+++ b/js/adyen.encrypt.nodom.js
@@ -168,6 +168,8 @@
         fnDefine('adyen/encrypt', [], function() {
             return encrypt;
         });
+    } else if (module && module.exports) {
+      module.exports = encrypt;
     }
     
         

--- a/package.json
+++ b/package.json
@@ -15,5 +15,13 @@
   "bugs": {
     "url": "https://github.com/Adyen/CSE-JS/issues"
   },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "jsdomify": "^2.1.0",
+    "mocha": "^2.4.5"
+  },
+  "scripts": {
+    "test": "./node_modules/.bin/mocha ./test/*.js"
+  },
   "homepage": "https://github.com/Adyen/CSE-JS#javascript-only-integration"
 }

--- a/test/adyen.encrypt.nodom.js
+++ b/test/adyen.encrypt.nodom.js
@@ -1,0 +1,18 @@
+var expect = require('chai').expect;
+var jsdomify = require('jsdomify').default;
+
+// mock dom api
+jsdomify.create();
+var navigator = jsdomify.getDocument().navigator;
+
+var adyenEncrypt = require('../js/adyen.encrypt.nodom');
+
+describe('adyenEncrypt', function () {
+  it('has createEncryption function', function () {
+    expect(adyenEncrypt).to.have.property('createEncryption');
+  });
+
+  it('has errors object', function () {
+    expect(adyenEncrypt).to.have.property('errors');
+  });
+});


### PR DESCRIPTION
Now you can use adyen as a regular node module.

I also added a test for that.

Run `npm install` to install test env dependecies.
Then run `npm test` to be sure that module returns the object you expect.
