### PR TITLE
Fixed typo, from `expiryMonth` to `expiryYear`

### DIFF
--- a/js/adyen.encrypt.nodom.js
+++ b/js/adyen.encrypt.nodom.js
@@ -397,7 +397,7 @@
         if (typeof data.expiryMonth !== "undefined") {
             validationObject.month = data.expiryMonth;
         }
-        if (typeof data.expiryMonth !== "undefined") {
+        if (typeof data.expiryYear !== "undefined") {
             validationObject.year = data.expiryYear;
         }
         if (typeof data.holderName !== "undefined") {


### PR DESCRIPTION
Fixed typo where was check of `typeof expiryMonth !== "undefined"` rather than `typeof data.expiryYear !== "undefined"`
