### PR TITLE
Fix exception in browser where module is undefined

### DIFF
--- a/js/adyen.encrypt.nodom.js
+++ b/js/adyen.encrypt.nodom.js
@@ -168,7 +168,7 @@
         fnDefine('adyen/encrypt', [], function() {
             return encrypt;
         });
-    } else if (module && module.exports) {
+    } else if (typeof module !== 'undefined' && module.exports) {
       module.exports = encrypt;
     }
     


### PR DESCRIPTION
Please, accept this fix because now library just broken in any browser
