### PR TITLE
Fix installing package as NPM dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "adyen-cse-js",
+  "name": "adyen-cse-web",
   "version": "0.1.21",
   "description": "Adyen javascript client-side encryption library",
   "main": "js/adyen.encrypt.nodom.js",


### PR DESCRIPTION
In README.md installing the package is referenced as:

```
"dependencies": {
  "adyen-cse-web": "git+https://github.com/Adyen/adyen-cse-web.git#v0.1.XX"
}
```

This does not do anything (on latest version) after running `npm install`, because the `name` of the Adyen package is different (`adyen-cse-js`).

Matching the name fixes the issue.